### PR TITLE
Title and progress bar in one line #43

### DIFF
--- a/src/css/panel.base.css
+++ b/src/css/panel.base.css
@@ -1,6 +1,6 @@
 .list-item {
   position: relative;
-  height: 30px;
+  height: 25px;
 }
 
 .list-item-content {
@@ -11,9 +11,8 @@
 
 .list-item-content .list-item-value {
   position: absolute;
-  z-index: 2;
+  z-index: 3;
   right: 0;
-  top: -9px;
 }
 
 .list-item-content .progress-item {
@@ -24,8 +23,13 @@
   position: absolute;
   z-index: 1;
   top: 0px;
-  height: 8px;
+  height: 20px;
   background: darkgreen;
+}
+
+.list-item-content .list-item-title {
+  position: absolute;
+  z-index: 2;
 }
 
 .options-tab .section {

--- a/src/css/panel.base.css
+++ b/src/css/panel.base.css
@@ -26,7 +26,6 @@
 
 .list-item-content .list-item-title {
   z-index: 1;
-  top: -9px;
 }
 
 .options-tab .section {

--- a/src/css/panel.base.css
+++ b/src/css/panel.base.css
@@ -1,10 +1,9 @@
 .list-item {
   position: relative;
-  height: 25px;
+  height: 30px;
 }
 
 .list-item-content {
-  position: relative;
   display: block;
   width: 99%;
 }
@@ -20,16 +19,14 @@
 }
 
 .list-item-content .progress-bar-line {
-  position: absolute;
-  z-index: 1;
+  z-index: 2;
   top: 0px;
-  height: 20px;
   background: darkgreen;
 }
 
 .list-item-content .list-item-title {
-  position: absolute;
-  z-index: 2;
+  z-index: 1;
+  top: -9px;
 }
 
 .options-tab .section {

--- a/src/directives/progress.html
+++ b/src/directives/progress.html
@@ -1,8 +1,14 @@
 <div class="list-item progress-item">
-  <div style="visibility: {{ item.titleHeaderView }}" class="list-item-title" ng-bind-html="item.title"></div>
+  <div class="list-item-title" ng-bind-html="item.title"></div>
   <div class="list-item-content">
-    <div style="width: {{ item.progress }}%; background: {{ item.color }}" class="progress-bar-line" />
-    <div style="visibility: {{ item.titleLineView }}" class="list-item-title" ng-bind-html="item.title"></div>
-    <span class="list-item-value progress-bar-value"> {{ item.formattedValue }} </span>
+    <div
+      style=
+        "width: {{ item.progress }}%;
+        background: {{ item.color }};
+        height: {{ item.titleParams.barHeight }}px;
+        margin-top: {{ item.titleParams.titleTop }}px;"
+      class="progress-bar-line"
+    />
+    <span style="top: {{ item.titleParams.valueTop }}px;" class="list-item-value progress-bar-value"> {{ item.formattedValue }} </span>
   </div>
 </div>

--- a/src/directives/progress.html
+++ b/src/directives/progress.html
@@ -1,7 +1,8 @@
 <div class="list-item progress-item">
-  <div class="list-item-title" ng-bind-html="item.title"></div>
+  <div style="visibility: hidden" class="list-item-title" ng-bind-html="item.title"></div>
   <div class="list-item-content">
     <div style="width: {{ item.progress }}%; background: {{ item.color }}" class="progress-bar-line" />
+    <div style="visibility: visible" class="list-item-title" ng-bind-html="item.title"></div>
     <span class="list-item-value progress-bar-value"> {{ item.formattedValue }} </span>
   </div>
 </div>

--- a/src/directives/progress.html
+++ b/src/directives/progress.html
@@ -1,8 +1,8 @@
 <div class="list-item progress-item">
-  <div style="visibility: hidden" class="list-item-title" ng-bind-html="item.title"></div>
+  <div style="visibility: {{ item.titleHeaderView }}" class="list-item-title" ng-bind-html="item.title"></div>
   <div class="list-item-content">
     <div style="width: {{ item.progress }}%; background: {{ item.color }}" class="progress-bar-line" />
-    <div style="visibility: visible" class="list-item-title" ng-bind-html="item.title"></div>
+    <div style="visibility: {{ item.titleLineView }}" class="list-item-title" ng-bind-html="item.title"></div>
     <span class="list-item-value progress-bar-value"> {{ item.formattedValue }} </span>
   </div>
 </div>

--- a/src/directives/progress.html
+++ b/src/directives/progress.html
@@ -2,13 +2,18 @@
   <div class="list-item-title" ng-bind-html="item.title"></div>
   <div class="list-item-content">
     <div
-      style=
-        "width: {{ item.progress }}%;
+      style="
+        width: {{ item.progress }}%;
         background: {{ item.color }};
         height: {{ item.titleParams.barHeight }}px;
-        margin-top: {{ item.titleParams.titleTop }}px;"
+        margin-top: {{ item.titleParams.titleTopMargin }}px;
+      "
       class="progress-bar-line"
     />
-    <span style="top: {{ item.titleParams.valueTop }}px;" class="list-item-value progress-bar-value"> {{ item.formattedValue }} </span>
+    <span
+      style="margin-top: {{ item.titleParams.valueTopMargin }}px;"
+      class="list-item-value progress-bar-value">
+      {{ item.formattedValue }}
+    </span>
   </div>
 </div>

--- a/src/directives/progress.html
+++ b/src/directives/progress.html
@@ -12,7 +12,8 @@
     />
     <span
       style="margin-top: {{ item.titleParams.valueTopMargin }}px;"
-      class="list-item-value progress-bar-value">
+      class="list-item-value progress-bar-value"
+    >
       {{ item.formattedValue }}
     </span>
   </div>

--- a/src/mapper.ts
+++ b/src/mapper.ts
@@ -149,7 +149,7 @@ export class ProgressItem {
     const titleType = this._panelConfig.getValue('titleViewType');
 
     switch(titleType) {
-      case TitleViewOptions.HEADER_LINE:
+      case TitleViewOptions.SEPARATE:
         return {
           barHeight: 8,
           titleTopMargin: 0,

--- a/src/mapper.ts
+++ b/src/mapper.ts
@@ -1,5 +1,7 @@
 import { PanelConfig } from './panel-config';
 
+import { TitleViewOptions } from './module';
+
 import * as _ from 'lodash';
 
 
@@ -150,16 +152,17 @@ export class ProgressItem {
       titleTopMargin: '0',
       valueTopMargin: '-22'
     }
-    if(titleType === 'auto') {
-      return titleParams;
+    switch(titleType) {
+      case TitleViewOptions.AUTO:
+        return titleParams;
+      case TitleViewOptions.INLINE:
+        titleParams.barHeight = '20';
+        titleParams.titleTopMargin = '-20';
+        titleParams.valueTopMargin = '-18';
+        return titleParams;
+      default:
+        throw new Error(`Wrong titleType: ${titleType}`);
     }
-    if(titleType === 'inline') {
-      titleParams.barHeight = '20';
-      titleParams.titleTopMargin = '-20';
-      titleParams.valueTopMargin = '-18';
-      return titleParams;
-    }
-    throw new Error('Unknown title view type ' + titleType);
   }
 
 }

--- a/src/mapper.ts
+++ b/src/mapper.ts
@@ -147,19 +147,20 @@ export class ProgressItem {
 
   get titleParams(): TitleViewParams {
     const titleType = this._panelConfig.getValue('titleViewType');
-    let titleParams = {
-      barHeight: '8',
-      titleTopMargin: '0',
-      valueTopMargin: '-22'
-    }
+
     switch(titleType) {
       case TitleViewOptions.AUTO:
-        return titleParams;
+        return {
+          barHeight: '8',
+          titleTopMargin: '0',
+          valueTopMargin: '-22'
+        };
       case TitleViewOptions.INLINE:
-        titleParams.barHeight = '20';
-        titleParams.titleTopMargin = '-20';
-        titleParams.valueTopMargin = '-18';
-        return titleParams;
+        return {
+          barHeight: '20',
+          titleTopMargin: '-20',
+          valueTopMargin: '-18'
+        };
       default:
         throw new Error(`Wrong titleType: ${titleType}`);
     }

--- a/src/mapper.ts
+++ b/src/mapper.ts
@@ -5,6 +5,11 @@ import * as _ from 'lodash';
 
 type KeyValue = [string, number];
 
+type TitleViewParams = {
+  barHeight: string,
+  titleTop: string,
+  valueTop: string
+}
 
 export class ProgressItem {
 
@@ -138,27 +143,25 @@ export class ProgressItem {
     throw new Error('Unknown color type ' + colorType);
   }
 
-  get titleHeaderView(): string {
+  get titleParams(): TitleViewParams {
     const titleType = this._panelConfig.getValue('titleViewType');
+    let titleParams = {
+      barHeight: '8',
+      titleTop: '0',
+      valueTop: '0'
+    }
     if(titleType === 'auto') {
-      return 'visible';
+      return titleParams;
     }
     if(titleType === 'inline') {
-      return 'hidden';
+      titleParams.barHeight = '20';
+      titleParams.titleTop = '-20';
+      titleParams.valueTop = '-3';
+      return titleParams;
     }
     throw new Error('Unknown title view type ' + titleType);
   }
 
-  get titleLineView(): string {
-    const titleType = this._panelConfig.getValue('titleViewType');
-    if(titleType === 'auto') {
-      return 'hidden';
-    }
-    if(titleType === 'inline') {
-      return 'visible';
-    }
-    throw new Error('Unknown title view type ' + titleType);
-  }
 }
 
 export class Mapper {

--- a/src/mapper.ts
+++ b/src/mapper.ts
@@ -7,8 +7,8 @@ type KeyValue = [string, number];
 
 type TitleViewParams = {
   barHeight: string,
-  titleTop: string,
-  valueTop: string
+  titleTopMargin: string,
+  valueTopMargin: string
 }
 
 export class ProgressItem {
@@ -147,16 +147,16 @@ export class ProgressItem {
     const titleType = this._panelConfig.getValue('titleViewType');
     let titleParams = {
       barHeight: '8',
-      titleTop: '0',
-      valueTop: '0'
+      titleTopMargin: '0',
+      valueTopMargin: '-22'
     }
     if(titleType === 'auto') {
       return titleParams;
     }
     if(titleType === 'inline') {
       titleParams.barHeight = '20';
-      titleParams.titleTop = '-20';
-      titleParams.valueTop = '-3';
+      titleParams.titleTopMargin = '-20';
+      titleParams.valueTopMargin = '-18';
       return titleParams;
     }
     throw new Error('Unknown title view type ' + titleType);

--- a/src/mapper.ts
+++ b/src/mapper.ts
@@ -9,7 +9,7 @@ type TitleViewParams = {
   barHeight: string,
   titleTopMargin: string,
   valueTopMargin: string
-}
+};
 
 export class ProgressItem {
 

--- a/src/mapper.ts
+++ b/src/mapper.ts
@@ -138,6 +138,27 @@ export class ProgressItem {
     throw new Error('Unknown color type ' + colorType);
   }
 
+  get titleHeaderView(): string {
+    const titleType = this._panelConfig.getValue('titleViewType');
+    if(titleType === 'auto') {
+      return 'visible';
+    }
+    if(titleType === 'inline') {
+      return 'hidden';
+    }
+    throw new Error('Unknown title view type ' + titleType);
+  }
+
+  get titleLineView(): string {
+    const titleType = this._panelConfig.getValue('titleViewType');
+    if(titleType === 'auto') {
+      return 'hidden';
+    }
+    if(titleType === 'inline') {
+      return 'visible';
+    }
+    throw new Error('Unknown title view type ' + titleType);
+  }
 }
 
 export class Mapper {

--- a/src/mapper.ts
+++ b/src/mapper.ts
@@ -8,9 +8,9 @@ import * as _ from 'lodash';
 type KeyValue = [string, number];
 
 type TitleViewParams = {
-  barHeight: string,
-  titleTopMargin: string,
-  valueTopMargin: string
+  barHeight: number,
+  titleTopMargin: number,
+  valueTopMargin: number
 };
 
 export class ProgressItem {
@@ -149,17 +149,17 @@ export class ProgressItem {
     const titleType = this._panelConfig.getValue('titleViewType');
 
     switch(titleType) {
-      case TitleViewOptions.AUTO:
+      case TitleViewOptions.HEADER_LINE:
         return {
-          barHeight: '8',
-          titleTopMargin: '0',
-          valueTopMargin: '-22'
+          barHeight: 8,
+          titleTopMargin: 0,
+          valueTopMargin: -22
         };
       case TitleViewOptions.INLINE:
         return {
-          barHeight: '20',
-          titleTopMargin: '-20',
-          valueTopMargin: '-18'
+          barHeight: 20,
+          titleTopMargin: -20,
+          valueTopMargin: -18
         };
       default:
         throw new Error(`Wrong titleType: ${titleType}`);

--- a/src/mapper.ts
+++ b/src/mapper.ts
@@ -149,7 +149,7 @@ export class ProgressItem {
     const titleType = this._panelConfig.getValue('titleViewType');
 
     switch(titleType) {
-      case TitleViewOptions.SEPARATE:
+      case TitleViewOptions.SEPARATE_TITLE_LINE:
         return {
           barHeight: 8,
           titleTopMargin: 0,

--- a/src/module.ts
+++ b/src/module.ts
@@ -6,6 +6,10 @@ import { MetricsPanelCtrl, loadPluginCss } from 'grafana/app/plugins/sdk';
 
 import * as _ from 'lodash';
 
+export enum TitleViewOptions {
+  AUTO = 'auto',
+  INLINE = 'inline'
+}
 
 const DEFAULTS = {
   statNameOptionValue: 'current',
@@ -41,7 +45,7 @@ class Ctrl extends MetricsPanelCtrl {
   private statNameOptions = [ 'current', 'min', 'max', 'total' ];
   private statProgressTypeOptions = [ 'max value', 'shared' ];
   private coloringTypeOptions = [ 'auto', 'thresholds', 'key mapping' ];
-  private titleViewTypeOptions = [ 'auto', 'inline' ];
+  private titleViewTypeOptions = [TitleViewOptions.AUTO, TitleViewOptions.INLINE];
   private sortingOrderOptions = [ 'none', 'increasing', 'decreasing' ];
   private valueLabelTypeOptions = [ 'absolute', 'percentage' ];
   // TODO: change option names or add a tip in editor

--- a/src/module.ts
+++ b/src/module.ts
@@ -12,6 +12,7 @@ const DEFAULTS = {
   statProgressType: 'shared',
   statProgressMaxValue: null,
   coloringType: 'auto',
+  titleViewType: 'auto',
   sortingOrder: 'none',
   valueLabelType: 'percentage',
   mappingType: 'datapoint to datapoint',
@@ -40,6 +41,7 @@ class Ctrl extends MetricsPanelCtrl {
   private statNameOptions = [ 'current', 'min', 'max', 'total' ];
   private statProgressTypeOptions = [ 'max value', 'shared' ];
   private coloringTypeOptions = [ 'auto', 'thresholds', 'key mapping' ];
+  private titleViewTypeOptions = [ 'auto', 'inline' ];
   private sortingOrderOptions = [ 'none', 'increasing', 'decreasing' ];
   private valueLabelTypeOptions = [ 'absolute', 'percentage' ];
   // TODO: change option names or add a tip in editor

--- a/src/module.ts
+++ b/src/module.ts
@@ -8,7 +8,7 @@ import * as _ from 'lodash';
 
 
 export enum TitleViewOptions {
-  SEPARATE = 'Separate title line',
+  SEPARATE_TITLE_LINE = 'Separate title line',
   INLINE = 'Inline'
 };
 
@@ -17,7 +17,7 @@ const DEFAULTS = {
   statProgressType: 'shared',
   statProgressMaxValue: null,
   coloringType: 'auto',
-  titleViewType: TitleViewOptions.SEPARATE,
+  titleViewType: TitleViewOptions.SEPARATE_TITLE_LINE,
   sortingOrder: 'none',
   valueLabelType: 'percentage',
   mappingType: 'datapoint to datapoint',

--- a/src/module.ts
+++ b/src/module.ts
@@ -8,8 +8,8 @@ import * as _ from 'lodash';
 
 
 export enum TitleViewOptions {
-  HEADER_LINE = 'header-line',
-  INLINE = 'inline'
+  SEPARATE = 'Separate title line',
+  INLINE = 'Inline'
 };
 
 const DEFAULTS = {
@@ -17,7 +17,7 @@ const DEFAULTS = {
   statProgressType: 'shared',
   statProgressMaxValue: null,
   coloringType: 'auto',
-  titleViewType: TitleViewOptions.HEADER_LINE,
+  titleViewType: TitleViewOptions.SEPARATE,
   sortingOrder: 'none',
   valueLabelType: 'percentage',
   mappingType: 'datapoint to datapoint',

--- a/src/module.ts
+++ b/src/module.ts
@@ -45,7 +45,7 @@ class Ctrl extends MetricsPanelCtrl {
   private statNameOptions = [ 'current', 'min', 'max', 'total' ];
   private statProgressTypeOptions = [ 'max value', 'shared' ];
   private coloringTypeOptions = [ 'auto', 'thresholds', 'key mapping' ];
-  private titleViewTypeOptions = [TitleViewOptions.AUTO, TitleViewOptions.INLINE];
+  private titleViewTypeOptions = _.values(TitleViewOptions);
   private sortingOrderOptions = [ 'none', 'increasing', 'decreasing' ];
   private valueLabelTypeOptions = [ 'absolute', 'percentage' ];
   // TODO: change option names or add a tip in editor

--- a/src/module.ts
+++ b/src/module.ts
@@ -8,7 +8,7 @@ import * as _ from 'lodash';
 
 
 export enum TitleViewOptions {
-  AUTO = 'auto',
+  HEADER_LINE = 'header-line',
   INLINE = 'inline'
 };
 
@@ -17,7 +17,7 @@ const DEFAULTS = {
   statProgressType: 'shared',
   statProgressMaxValue: null,
   coloringType: 'auto',
-  titleViewType: TitleViewOptions.AUTO,
+  titleViewType: TitleViewOptions.HEADER_LINE,
   sortingOrder: 'none',
   valueLabelType: 'percentage',
   mappingType: 'datapoint to datapoint',

--- a/src/module.ts
+++ b/src/module.ts
@@ -6,17 +6,18 @@ import { MetricsPanelCtrl, loadPluginCss } from 'grafana/app/plugins/sdk';
 
 import * as _ from 'lodash';
 
+
 export enum TitleViewOptions {
   AUTO = 'auto',
   INLINE = 'inline'
-}
+};
 
 const DEFAULTS = {
   statNameOptionValue: 'current',
   statProgressType: 'shared',
   statProgressMaxValue: null,
   coloringType: 'auto',
-  titleViewType: 'auto',
+  titleViewType: TitleViewOptions.AUTO,
   sortingOrder: 'none',
   valueLabelType: 'percentage',
   mappingType: 'datapoint to datapoint',

--- a/src/partials/options.html
+++ b/src/partials/options.html
@@ -245,7 +245,19 @@
       </div>
 
     </div>
-
+    <br>
+    <h5 class="section-heading">Title view<h5>
+    <div class="gf-form">
+      <label class="gf-form-label width-8">Type</label>
+      <div class="gf-form-select-wrapper width-11">
+        <select
+          class="gf-form-input"
+          ng-model="ctrl.panel.titleViewType"
+          ng-options="n for n in ctrl.titleViewTypeOptions"
+          ng-change="ctrl.render()"
+        />
+      </div>
+    </div>
   </div>
 
 </div>

--- a/src/partials/options.html
+++ b/src/partials/options.html
@@ -133,7 +133,7 @@
       <h5 class="section-heading">Key Labels</h5>
       <div class="gf-form">
         <label class="gf-form-label width-6">Title Type</label>
-        <div class="gf-form-select-wrapper width-10">
+        <div class="gf-form-select-wrapper width-11">
           <select
             class="gf-form-input"
             ng-model="ctrl.panel.titleViewType"

--- a/src/partials/options.html
+++ b/src/partials/options.html
@@ -131,6 +131,17 @@
     <br>
     <div class="section gf-form-group">
       <h5 class="section-heading">Key Labels</h5>
+      <div class="gf-form">
+        <label class="gf-form-label width-6">Title Type</label>
+        <div class="gf-form-select-wrapper width-10">
+          <select
+            class="gf-form-input"
+            ng-model="ctrl.panel.titleViewType"
+            ng-options="n for n in ctrl.titleViewTypeOptions"
+            ng-change="ctrl.render()"
+          />
+        </div>
+      </div>
       <div class="gf-form-inline">
         <div class="gf-form">
           <label class="gf-form-label width-6">
@@ -245,19 +256,7 @@
       </div>
 
     </div>
-    <br>
-    <h5 class="section-heading">Title view<h5>
-    <div class="gf-form">
-      <label class="gf-form-label width-8">Type</label>
-      <div class="gf-form-select-wrapper width-11">
-        <select
-          class="gf-form-input"
-          ng-model="ctrl.panel.titleViewType"
-          ng-options="n for n in ctrl.titleViewTypeOptions"
-          ng-change="ctrl.render()"
-        />
-      </div>
-    </div>
+
   </div>
 
 </div>


### PR DESCRIPTION
Closes #43 

### Changes:

 - add new line `Title Type` in `Key Labels` with two options: `Separate title line` and `inline`;
 - title and progress bar will be in one line with option `inline`;

### `Separate title line`:

![image](https://user-images.githubusercontent.com/39257464/68946388-ecbc4500-07c3-11ea-91b2-73f1c120de93.png)

![image](https://user-images.githubusercontent.com/39257464/68879918-546a8580-071b-11ea-99df-015a2559450c.png)


### `inline`:

![image](https://user-images.githubusercontent.com/39257464/68946462-1c6b4d00-07c4-11ea-88d8-858412e4e038.png)

![photo_2019-11-14_20-02-51](https://user-images.githubusercontent.com/39257464/68879935-5cc2c080-071b-11ea-9811-a82aa2f15b8d.jpg)

