### PR TITLE
Long lists bad init rendering #59

### DIFF
--- a/src/css/panel.base.css
+++ b/src/css/panel.base.css
@@ -1,3 +1,8 @@
+.progress-list-panel {
+  height: 100%;
+  overflow-y: auto;
+}
+
 .list-item {
   position: relative;
   height: 30px;

--- a/src/module.ts
+++ b/src/module.ts
@@ -137,10 +137,6 @@ class Ctrl extends MetricsPanelCtrl {
       items = _.sortBy(items, i => -i.aggregatedProgress);
     }
     this.$scope.items = items;
-    this._element.find('.table-panel-scroll').css({
-      'height': `${this.height}px`,
-      'max-height': `${this.height}px`
-    });
 
     if(this._tooltip !== undefined) {
       this._tooltip.destroy();

--- a/src/partials/template.html
+++ b/src/partials/template.html
@@ -1,4 +1,4 @@
-<div id="progress-list-panel">
+<div class="progress-list-panel">
   <div class="table-panel-scroll" ng-if="!ctrl.isPanelAlert">
     <div ng-repeat="item in items" ng-if="!ctrl.isMultibar">
       <progress-list-plugin-progress

--- a/src/partials/template.html
+++ b/src/partials/template.html
@@ -1,5 +1,5 @@
 <div class="progress-list-panel">
-  <div class="table-panel-scroll" ng-if="!ctrl.isPanelAlert">
+  <div ng-if="!ctrl.isPanelAlert">
     <div ng-repeat="item in items" ng-if="!ctrl.isMultibar">
       <progress-list-plugin-progress
         class="progress-list-item"


### PR DESCRIPTION
Fixes #59 

## Problem

Can't set `max-height` of `.table-panel-scroll` because it is not in the DOM in the beginning. 

In `Ctrl._onRender()` setting css fields of `$('.table-panel-scroll')` could not be set because the element is not in the DOM because 
`ctrl.isPanelAlert` is `false`.

## Solution

New styles in `panel.base.css`:

```
.progress-list-panel {
  height: 100%;
  overflow-y: auto;
}
```


## Changes

* new styles in `panel.base.css`
* remove logic of setting css filed  related to the height from `Ctrl._onRender()`
* remove of `table-panel-scroll` class from `template.html`
* change the root html element from id to class: `<div id="progress-list-panel">` to `<div class="progress-list-panel">`


### Other

Our method `_OnRender()` works faster now because there is no extra jquery call and setting css field. Maybe we can improve the performance of this method and don't map metrics on each resize of the panel. Yes, resizing of the panels invokes `_onRender()`