### PR TITLE
Multibar coloring, ProgressBar and config types

### DIFF
--- a/src/css/panel.base.css
+++ b/src/css/panel.base.css
@@ -27,6 +27,9 @@
   z-index: 2;
   top: 0px;
   background: darkgreen;
+  border-right-width: 2px;
+  border-right-style: solid;
+  border-right-color: gray;
 }
 
 .progress-bar .progress-bar-title {

--- a/src/css/panel.base.css
+++ b/src/css/panel.base.css
@@ -12,24 +12,24 @@
   font-weight: bold;
 }
 
-.list-item-content {
+.progress-bar .list-item-content {
   display: block;
   width: 99%;
 }
 
-.list-item-content .list-item-value {
+.progress-bar .list-item-content .list-item-value {
   position: absolute;
   z-index: 3;
   right: 0;
 }
 
-.list-item-content .progress-bar-line {
+.progress-bar .list-item-content .progress-bar-line {
   z-index: 2;
   top: 0px;
   background: darkgreen;
 }
 
-.list-item-title {
+.progress-bar .progress-bar-title {
   margin-bottom: -8px;
 }
 

--- a/src/css/panel.base.css
+++ b/src/css/panel.base.css
@@ -3,9 +3,13 @@
   overflow-y: auto;
 }
 
-.list-item {
+.progress-bar {
   position: relative;
   height: 34px;
+}
+
+.progress-bar-active {
+  font-weight: bold;
 }
 
 .list-item-content {

--- a/src/graph_tooltip.ts
+++ b/src/graph_tooltip.ts
@@ -1,6 +1,6 @@
 import * as _ from 'lodash';
 
-import { Bar } from './progress_bar'
+import { Bar, ProgressBar } from './progress_bar'
 import { TooltipMode } from './panel_config';
 
 
@@ -16,37 +16,6 @@ export type Serie = {
   alias?: string
 };
 
-export class TooltipItem {
-  constructor(
-    public active: boolean, 
-    public name: string,
-    public elems: Bar[]
-  ) {
-  }
-
-  toHtml(): string {
-    return `
-      <div class="graph-tooltip-list-item">
-        <div class="graph-tooltip-series-name">
-          ${this.active ? '<b>' : ''} 
-          ${this.name}
-          ${this.active ? '</b>' : ''}
-        </div>
-        ${this._valuesToHtml()}
-      </div>
-    `;
-  }
-  
-  private _valuesToHtml(): string {
-    return this.elems.map(barElem => `
-      <div class="graph-tooltip-value">
-        ${barElem.value}
-      </div>
-    `).join('');
-  }
-
-}
-
 export class GraphTooltip {
 
   private $tooltip: JQuery<HTMLElement>;
@@ -56,7 +25,7 @@ export class GraphTooltip {
     this.$tooltip = $('<div class="graph-tooltip">');
   }
 
-  show(pos: Position, items: TooltipItem[], mode: TooltipMode): void {
+  show(pos: Position, progressBars: ProgressBar[], mode: TooltipMode): void {
     if(mode == TooltipMode.NONE) {
       return;
     }
@@ -64,17 +33,17 @@ export class GraphTooltip {
     // TODO: use more vue/react approach here
     // TODO: maybe wrap this rendering logic into classes
     if(mode == TooltipMode.SINGLE) {
-      let activeItem = _.find(items, item => item.active);
+      let activeItem = _.find(progressBars, item => item.active);
       var html = `<div class="graph-tooltip-time">Current value</div>`;
       if(activeItem === undefined) {
         throw new Error(
           'Can`t find any active item to show current value in tooltip'
         );
       }
-      html += activeItem.toHtml();
+      html += progressBar2Html(activeItem);
     } else if (mode == TooltipMode.ALL_SERIES) {
       // TODO: build this string faster
-      var html = items.map(i => i.toHtml()).join('');
+      var html = progressBars.map(progressBar2Html).join('');
     } else {
       throw new Error('unknown tooltip type');
     }
@@ -91,4 +60,27 @@ export class GraphTooltip {
 
   get visible(): boolean { return this._visible; }
 
+}
+
+/** VIEW **/
+
+function progressBar2Html(progressBar: ProgressBar): string {
+  return `
+    <div class="graph-tooltip-list-item">
+      <div class="graph-tooltip-series-name">
+        ${progressBar.active ? '<b>' : ''} 
+        ${progressBar.title}
+        ${progressBar.active ? '</b>' : ''}
+      </div>
+      ${progressBarBars2Html(progressBar.bars)}
+    </div>
+  `;
+}
+
+function progressBarBars2Html(bars: Bar[]): string {
+  return bars.map(bar => `
+    <div class="graph-tooltip-value">
+      ${bar.value}
+    </div>
+  `).join('');
 }

--- a/src/graph_tooltip.ts
+++ b/src/graph_tooltip.ts
@@ -1,11 +1,7 @@
 import * as _ from 'lodash';
 
+import { TooltipMode } from './panel_config';
 
-export enum TooltipMode {
-  NONE = 'none',
-  SINGLE = 'single',
-  ALL_SERIES = 'all series'
-};
 
 export type Position = {
   pageX: number,
@@ -98,5 +94,4 @@ export class GraphTooltip {
 
   get visible(): boolean { return this._visible; }
 
-  
 }

--- a/src/graph_tooltip.ts
+++ b/src/graph_tooltip.ts
@@ -1,5 +1,6 @@
 import * as _ from 'lodash';
 
+import { Bar } from './progress_bar'
 import { TooltipMode } from './panel_config';
 
 
@@ -14,16 +15,11 @@ export type Serie = {
   alias?: string
 };
 
-export type TooltipValue = {
-  value: string,
-  color: string
-}
-
 export class TooltipItem {
   constructor(
     public active: boolean, 
     public name: string,
-    public values: TooltipValue[]
+    public elems: Bar[]
   ) {
   }
 
@@ -41,9 +37,9 @@ export class TooltipItem {
   }
   
   private _valuesToHtml(): string {
-    return this.values.map(v => `
+    return this.elems.map(barElem => `
       <div class="graph-tooltip-value">
-        ${v.value}
+        ${barElem.value}
       </div>
     `).join('');
   }

--- a/src/graph_tooltip.ts
+++ b/src/graph_tooltip.ts
@@ -68,7 +68,7 @@ function progressBar2Html(progressBar: ProgressBar): string {
   return `
     <div class="graph-tooltip-list-item">
       <div class="graph-tooltip-series-name">
-        ${progressBar.active ? '<b>' : ''} 
+        ${progressBar.active ? '<b>' : ''}
         ${progressBar.title}
         ${progressBar.active ? '</b>' : ''}
       </div>

--- a/src/graph_tooltip.ts
+++ b/src/graph_tooltip.ts
@@ -9,6 +9,7 @@ export type Position = {
   pageY: number
 };
 
+// TODO: check if we need this
 export type Serie = {
   datapoints: [number, number][],
   target: string,

--- a/src/mapper.ts
+++ b/src/mapper.ts
@@ -42,21 +42,19 @@ export class Mapper {
       keyIndex = keys.findIndex(key => key === keyColumn);
     }
 
-    const title = keys[keyIndex];
-
     let skipIndexes: number[] = [keyIndex];
     const skipColumn = this._panelConfig.getValue('skipColumn');
     if(skipColumn !== '') {
       skipIndexes.push(keys.findIndex(key => key === skipColumn));
     }
 
-    const maxValue = _.max(
-      seriesList[0].rows.map(
-        row => _.sum(
-          row.filter((value, idx) => !_.includes(skipIndexes, idx))
-        )
+    
+    const rowMaxes =  seriesList[0].rows.map(
+      row => _.sum(
+        row.filter((value, idx) => !_.includes(skipIndexes, idx))
       )
     );
+    const maxValue = _.max(rowMaxes);
 
     const filteredKeys = keys.filter((key, idx) => !_.includes(skipIndexes, idx));
 
@@ -71,35 +69,6 @@ export class Mapper {
       )
     );
 
-  }
-
-  // TODO: enum statProgressType
-  _getMaxValue(
-    kstat: KeyValue[],
-    statProgressType: string,
-    statProgressMaxValue: number | null
-  ): number {
-    if(statProgressType === 'shared') {
-      let total = 0;
-      for(let i = 0; i < kstat.length; i++) {
-        total += kstat[i][1];
-      }
-      return total;
-    }
-
-    if(statProgressType === 'max value') {
-      let max = -Infinity;
-      if(statProgressMaxValue !== null) {
-        max = statProgressMaxValue;
-      } else {
-        for(let i = 0; i < kstat.length; i++) {
-          max = Math.max(kstat[i][1], max);
-        }
-      }
-      return max;
-    }
-
-    return -1;
   }
 
   _mapKeysTotal(seriesList): KeyValue[] {

--- a/src/mapper.ts
+++ b/src/mapper.ts
@@ -1,242 +1,12 @@
-import { PanelConfig } from './panel_config';
-import { getFormattedValue } from './value_formatter';
+import { ProgressBar } from './progress_bar';
+import { PanelConfig, StatType } from './panel_config';
 
-import { TitleViewOptions } from './module';
 
 import * as _ from 'lodash';
 
 
 type KeyValue = [string, number];
 
-export enum StatType {
-  CURRENT = 'current',
-  MIN = 'min',
-  MAX = 'max',
-  TOTAL = 'total'
-};
-
-type TitleViewParams = {
-  barHeight: number,
-  titleTopMargin: number,
-  valueTopMargin: number
-};
-
-export class MultiProgressItem {
-  constructor(
-    private _panelConfig: PanelConfig,
-    private _title: string,
-    private _keys: string[],
-    private _values: number[],
-    private _maxValue: number
-  ) {
-    if(this._keys.length !== this._values.length) {
-      throw new Error('keys amount should be equal to values amount');
-    }
-  }
-
-  get title(): string {
-    return this._title;
-  }
-
-  get keys(): string[] {
-    return this._keys;
-  }
-
-  get values(): number[] {
-    return this._values;
-  }
-
-  get sumOfValues(): number {
-    return _.sum(this.values);
-  }
-
-  get percentValues(): number[] {
-    // TODO: this.sumOfValues * 1.1 is a hack to make sure bars don't wrap
-    // (they are wrapped when total width > 98%)
-    return this.values.map(
-      value => Math.floor(value / (this.sumOfValues * 1.1) * 100)
-    );
-  }
-
-  get colors(): string[] {
-    // TODO: customize colors
-    return ['green', 'yellow', 'red'];
-  }
-
-  get aggregatedProgress(): number {
-    return (_.sum(this.values) / this._maxValue) * 100;
-  }
-
-  get formattedValue(): string {
-    return getFormattedValue(
-      this.sumOfValues,
-      this._panelConfig.getValue('prefix'),
-      this._panelConfig.getValue('postfix'),
-      this._panelConfig.getValue('decimals')
-    );
-  }
-
-  get titleParams(): TitleViewParams {
-    const titleType = this._panelConfig.getValue('titleViewType');
-
-    switch(titleType) {
-      case TitleViewOptions.SEPARATE_TITLE_LINE:
-        return {
-          barHeight: 8,
-          titleTopMargin: 0,
-          valueTopMargin: -12
-        };
-      case TitleViewOptions.INLINE:
-        return {
-          barHeight: 20,
-          titleTopMargin: -20,
-          valueTopMargin: -18
-        };
-      default:
-        throw new Error(`Wrong titleType: ${titleType}`);
-    }
-  }
-
-  get opacity(): string {
-    return this._panelConfig.getValue('opacity');
-  }
-}
-
-export class ProgressItem {
-
-  private _panelConfig: PanelConfig;
-
-  private _key: string;
-  private _aggregatedValue: number;
-  private _maxAggregatedValue: number;
-  private _currentValue: number;
-  private _currentMaxValue: number;
-
-  constructor(
-    panelConfig: PanelConfig,
-    key: string,
-    aggregatedValue: number,
-    maxAggregatedValue: number,
-    currentValue: number,
-    currentMaxValue: number
-  ) {
-    this._panelConfig = panelConfig;
-    this._key = key;
-    this._aggregatedValue = aggregatedValue;
-    this._maxAggregatedValue = maxAggregatedValue;
-    // TODO: currentValue and currentMaxValue is not the best idea
-    this._currentValue = currentValue;
-    this._currentMaxValue = currentMaxValue;
-  }
-
-  get title(): string {
-    return this._key;
-  }
-
-  get aggregatedProgress(): number {
-    return 100 * this._aggregatedValue / this._maxAggregatedValue;
-  }
-
-  get currentProgress(): number {
-    return 100 * this._currentValue / this._currentMaxValue;
-  }
-
-  get maxValue(): number {
-    return this._maxAggregatedValue;
-  }
-
-  get aggregatedValue(): number {
-    return this._aggregatedValue;
-  }
-
-  get currentValue(): number {
-    return this._currentValue;
-  }
-
-  get currentFormattedValue(): string {
-    const value =
-      this._panelConfig.getValue('valueLabelType') === 'percentage' ?
-        this.currentProgress :
-        this._currentValue;
-    return getFormattedValue(
-      value,
-      this._panelConfig.getValue('prefix'),
-      this._panelConfig.getValue('postfix'),
-      this._panelConfig.getValue('decimals')
-    );
-  }
-
-  get formattedValue(): string {
-    const value =
-      this._panelConfig.getValue('valueLabelType') === 'percentage'
-        ? this.aggregatedProgress
-        : this._aggregatedValue;
-    return getFormattedValue(
-      value,
-      this._panelConfig.getValue('prefix'),
-      this._panelConfig.getValue('postfix'),
-      this._panelConfig.getValue('decimals')
-    );
-  }
-
-  get opacity(): string {
-    return this._panelConfig.getValue('opacity');
-  }
-
-  get color(): string {
-    var colorType = this._panelConfig.getValue('coloringType');
-    if(colorType === 'auto') {
-      return 'auto'
-    }
-    if(colorType === 'thresholds') {
-      var thresholdsStr = this._panelConfig.getValue('thresholds');
-      var colors = this._panelConfig.getValue('colors');
-      var value = this.aggregatedProgress;
-      if(thresholdsStr === undefined) {
-        return colors[0];
-      }
-      var thresholds = thresholdsStr.split(',').map(parseFloat);
-      for(var i = thresholds.length; i > 0; i--) {
-        if(value >= thresholds[i - 1]) {
-          return colors[i];
-        }
-      }
-      return colors[0];
-    }
-    if(colorType === 'key mapping') {
-      var colorKeyMappings = this._panelConfig.getValue('colorKeyMappings') as any[];
-      var keyColorMapping = _.find(colorKeyMappings, k => k.key === this._key);
-      if(keyColorMapping === undefined) {
-        return this._panelConfig.getValue('colorsKeyMappingDefault');
-      }
-      return keyColorMapping.color;
-    }
-
-    throw new Error('Unknown color type ' + colorType);
-  }
-
-  get titleParams(): TitleViewParams {
-    const titleType = this._panelConfig.getValue('titleViewType');
-
-    switch(titleType) {
-      case TitleViewOptions.SEPARATE_TITLE_LINE:
-        return {
-          barHeight: 8,
-          titleTopMargin: 0,
-          valueTopMargin: -22
-        };
-      case TitleViewOptions.INLINE:
-        return {
-          barHeight: 20,
-          titleTopMargin: -20,
-          valueTopMargin: -18
-        };
-      default:
-        throw new Error(`Wrong titleType: ${titleType}`);
-    }
-  }
-
-}
 
 export class Mapper {
 
@@ -248,7 +18,7 @@ export class Mapper {
     this._templateSrv = templateSrv;
   }
 
-  mapMetricData(seriesList: any): ProgressItem[] {
+  mapMetricData(seriesList: any): ProgressBar[] {
     const statType: StatType = this._panelConfig.getValue('statNameOptionValue');
     const mappingType = this._panelConfig.getValue('mappingType');
     const statProgressType = this._panelConfig.getValue('statProgressType');
@@ -263,80 +33,44 @@ export class Mapper {
     let kstat: KeyValue[] = [];
     let currentStat: KeyValue[] = [];
 
-    if(seriesList[0].columns !== undefined) {
-      let keys = seriesList[0].columns.map(col => col.text);
+  
+    let keys = seriesList[0].columns.map(col => col.text);
 
-      const keyColumn = this._panelConfig.getValue('keyColumn');
-      let keyIndex = 0;
-      if(keyColumn !== '') {
-        keyIndex = keys.findIndex(key => key === keyColumn);
-      }
+    const keyColumn = this._panelConfig.getValue('keyColumn');
+    let keyIndex = 0;
+    if(keyColumn !== '') {
+      keyIndex = keys.findIndex(key => key === keyColumn);
+    }
 
-      const title = keys[keyIndex];
+    const title = keys[keyIndex];
 
-      let skipIndexes: number[] = [keyIndex];
-      const skipColumn = this._panelConfig.getValue('skipColumn');
-      if(skipColumn !== '') {
-        skipIndexes.push(keys.findIndex(key => key === skipColumn));
-      }
+    let skipIndexes: number[] = [keyIndex];
+    const skipColumn = this._panelConfig.getValue('skipColumn');
+    if(skipColumn !== '') {
+      skipIndexes.push(keys.findIndex(key => key === skipColumn));
+    }
 
-      const maxValue = _.max(
-        seriesList[0].rows.map(
-          row => _.sum(
-            row.filter((value, idx) => !_.includes(skipIndexes, idx))
-          )
+    const maxValue = _.max(
+      seriesList[0].rows.map(
+        row => _.sum(
+          row.filter((value, idx) => !_.includes(skipIndexes, idx))
         )
-      );
-
-      const filteredKeys = keys.filter((key, idx) => !_.includes(skipIndexes, idx));
-      
-      // TODO: it's wrong, we return a bad type here
-      return seriesList[0].rows.map(
-        row => new MultiProgressItem(
-          this._panelConfig,
-          row[keyIndex],
-          filteredKeys,
-          row.filter((value, idx) => !_.includes(skipIndexes, idx)),
-          maxValue as number
-        )
-      );
-    }
-
-    if(mappingType === 'datapoint to datapoint') {
-      if(statType === StatType.TOTAL && seriesList.length == 1) {
-        kstat = this._mapKeysTotal(seriesList);
-      } else {
-        kstat = this._mapNumeric(seriesList, statType, nullMapping);
-      }
-      currentStat = this._mapNumeric(seriesList, StatType.CURRENT, nullMapping);
-    } else {
-      kstat = this._mapTargetToDatapoints(seriesList, statType);
-      currentStat = this._mapTargetToDatapoints(seriesList, StatType.CURRENT);
-    }
-
-    const maxValue = this._getMaxValue(kstat, statProgressType, statProgressMaxValue);
-    const currentMaxValue = this._getMaxValue(currentStat, statProgressType, statProgressMaxValue);
-
-    if(alias !== '') {
-      kstat.forEach(k => {
-        const scopedVars = {
-          __key: { value: k[0] }
-        };
-        k[0] = this._templateSrv.replace(alias, scopedVars);
-      });
-    }
-
-    return _.map(
-      kstat,
-      (k: KeyValue, idx: number) => new ProgressItem(
-        this._panelConfig,
-        k[0],
-        k[1],
-        maxValue,
-        currentStat[idx][1],
-        currentMaxValue
       )
     );
+
+    const filteredKeys = keys.filter((key, idx) => !_.includes(skipIndexes, idx));
+    
+    // TODO: it's wrong, we return a bad type here
+    return seriesList[0].rows.map(
+      row => new ProgressBar(
+        this._panelConfig,
+        row[keyIndex],
+        filteredKeys,
+        row.filter((value, idx) => !_.includes(skipIndexes, idx)),
+        maxValue as number
+      )
+    );
+    
   }
 
   // TODO: enum statProgressType

--- a/src/mapper.ts
+++ b/src/mapper.ts
@@ -33,7 +33,7 @@ export class Mapper {
     let kstat: KeyValue[] = [];
     let currentStat: KeyValue[] = [];
 
-  
+
     let keys = seriesList[0].columns.map(col => col.text);
 
     const keyColumn = this._panelConfig.getValue('keyColumn');
@@ -59,7 +59,7 @@ export class Mapper {
     );
 
     const filteredKeys = keys.filter((key, idx) => !_.includes(skipIndexes, idx));
-    
+
     // TODO: it's wrong, we return a bad type here
     return seriesList[0].rows.map(
       row => new ProgressBar(
@@ -70,7 +70,7 @@ export class Mapper {
         maxValue as number
       )
     );
-    
+
   }
 
   // TODO: enum statProgressType

--- a/src/mapper.ts
+++ b/src/mapper.ts
@@ -49,13 +49,12 @@ export class Mapper {
     }
 
     
-    const rowMaxes =  seriesList[0].rows.map(
+    const firstRowMaxes =  seriesList[0].rows.map(
       row => _.sum(
         row.filter((value, idx) => !_.includes(skipIndexes, idx))
       )
     );
-    const maxValue = _.max(rowMaxes);
-
+    const maxValue = _.max(firstRowMaxes);
     const filteredKeys = keys.filter((key, idx) => !_.includes(skipIndexes, idx));
 
     // TODO: it's wrong, we return a bad type here

--- a/src/module.ts
+++ b/src/module.ts
@@ -24,7 +24,7 @@ class Ctrl extends MetricsPanelCtrl {
   public mapper: Mapper;
 
   // TODO: rename progressBars
-  public items: ProgressBar[];
+  public progressBars: ProgressBar[];
 
   private _panelConfig: PanelConfig.PanelConfig;
   private _element: any;
@@ -66,7 +66,7 @@ class Ctrl extends MetricsPanelCtrl {
     this._initStyles();
 
     this.mapper = new Mapper(this._panelConfig, this.templateSrv);
-    this.items = [];
+    this.progressBars = [];
     this._tooltip = new GraphTooltip();
 
     this.events.on('init-edit-mode', this._onInitEditMode.bind(this));
@@ -101,19 +101,19 @@ class Ctrl extends MetricsPanelCtrl {
     }
     try {
       // TODO: set this.items also
-      this.items = this.mapper.mapMetricData(this._seriesList);
+      this.progressBars = this.mapper.mapMetricData(this._seriesList);
     } catch(e) {
       this._panelAlert.active = true;
       this._panelAlert.message = ERROR_MAPPING;
       return;
     }
     if(this._panelConfig.getValue('sortingOrder') === 'increasing') {
-      this.items = _.sortBy(this.items, i => i.aggregatedProgress);
+      this.progressBars = _.sortBy(this.progressBars, i => i.aggregatedProgress);
     }
     if(this._panelConfig.getValue('sortingOrder') === 'decreasing') {
-      this.items = _.sortBy(this.items, i => -i.aggregatedProgress);
+      this.progressBars = _.sortBy(this.progressBars, i => -i.aggregatedProgress);
     }
-    this.$scope.items = this.items;
+    this.$scope.items = this.progressBars;
 
     if(this._tooltip.visible) {
       if(this._lastHoverEvent === undefined) {
@@ -127,14 +127,11 @@ class Ctrl extends MetricsPanelCtrl {
   }
 
   onHover(event: HoverEvent) {
-    this._lastHoverEvent = event;
-    let tooltipItems: TooltipItem[] = _.map(this.items, (item, i) => new TooltipItem(
+    this._lastHoverEvent = event; // TODO: use it to unset active previous progressbar
+    let tooltipItems: TooltipItem[] = _.map(this.progressBars, (item, i) => new TooltipItem(
       i == event.index,
       item.title, // previously wwe showed serie.alias || serie.target
-      [{
-        value: item.formattedValue,
-        color: item.colors[0] // TODO: use other colors here
-      }]
+      item.bars
     ));
     this._tooltip.show(event.event, tooltipItems, this.panel.tooltipMode);
   }

--- a/src/module.ts
+++ b/src/module.ts
@@ -27,13 +27,13 @@ class Ctrl extends MetricsPanelCtrl {
   public progressBars: ProgressBar[];
 
   private _panelConfig: PanelConfig.PanelConfig;
-  private _element: any;
 
   private _seriesList: any;
 
   private _tooltip: GraphTooltip;
 
   private statNameOptions = _.values(PanelConfig.StatType);
+  // TODO: review these ooptions and make types in PanelConfig
   private statProgressTypeOptions = [ 'max value', 'shared' ];
   private coloringTypeOptions = [ 'auto', 'thresholds', 'key mapping' ];
   private titleViewTypeOptions = _.values(PanelConfig.TitleViewOptions);
@@ -72,10 +72,6 @@ class Ctrl extends MetricsPanelCtrl {
     this.events.on('init-edit-mode', this._onInitEditMode.bind(this));
     this.events.on('data-received', this._onDataReceived.bind(this));
     this.events.on('render', this._onRender.bind(this));
-  }
-
-  link(scope, element) {
-    this._element = element;
   }
 
   _initStyles() {
@@ -134,7 +130,7 @@ class Ctrl extends MetricsPanelCtrl {
 
   private _clearActiveProgressBar() {
     if(
-      this._lastHoverEvent !== undefined && 
+      this._lastHoverEvent !== undefined &&
       this._lastHoverEvent.index < this.progressBars.length
     ) {
       this.progressBars[this._lastHoverEvent.index].active = false;

--- a/src/module.ts
+++ b/src/module.ts
@@ -13,8 +13,10 @@ export type HoverEvent = {
 }
 
 const ERROR_MAPPING = `
-  Can't map the received metrics,
-  see <strong> <a href="https://github.com/CorpGlory/grafana-progress-list/wiki">wiki</a> </strong>
+  Can't map the received metrics, see 
+  <strong>
+    <a href="https://github.com/CorpGlory/grafana-progress-list/wiki">wiki</a>
+  </strong>
 `;
 const ERROR_NO_DATA = "no data";
 
@@ -35,7 +37,9 @@ class Ctrl extends MetricsPanelCtrl {
   private statNameOptions = _.values(PanelConfig.StatType);
   // TODO: review these ooptions and make types in PanelConfig
   private statProgressTypeOptions = [ 'max value', 'shared' ];
-  private coloringTypeOptions = [ 'auto', 'thresholds', 'key mapping' ];
+  
+  private coloringTypeOptions = _.values(PanelConfig.ColoringType);
+
   private titleViewTypeOptions = _.values(PanelConfig.TitleViewOptions);
   private sortingOrderOptions = [ 'none', 'increasing', 'decreasing' ];
   private valueLabelTypeOptions = [ 'absolute', 'percentage' ];

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,16 +1,16 @@
-import { GraphTooltip, TooltipMode, TooltipItem } from './graph_tooltip';
-import { PanelConfig } from './panel_config';
-import { Mapper, ProgressItem, StatType } from './mapper';
+import { GraphTooltip, TooltipItem } from './graph_tooltip';
+import * as PanelConfig from './panel_config';
+import { Mapper } from './mapper';
+import { ProgressBar } from './progress_bar';
 
 import { MetricsPanelCtrl, loadPluginCss } from 'grafana/app/plugins/sdk';
 
 import * as _ from 'lodash';
 
-
-export enum TitleViewOptions {
-  SEPARATE_TITLE_LINE = 'Separate title line',
-  INLINE = 'Inline'
-};
+export type HoverEvent = {
+  index: number,
+  event: any
+}
 
 const ERROR_MAPPING = `
   Can't map the received metrics,
@@ -18,58 +18,30 @@ const ERROR_MAPPING = `
 `;
 const ERROR_NO_DATA = "no data";
 
-export type HoverEvent = {
-  index: number,
-  event: any
-}
-
-const DEFAULTS = {
-  keyColumn: '',
-  // TODO: skip multiple columns
-  skipColumn: '',
-  statNameOptionValue: StatType.CURRENT,
-  statProgressType: 'shared',
-  statProgressMaxValue: null,
-  coloringType: 'auto',
-  titleViewType: TitleViewOptions.SEPARATE_TITLE_LINE,
-  sortingOrder: 'none',
-  valueLabelType: 'percentage',
-  mappingType: 'datapoint to datapoint',
-  alias: '',
-  prefix: '',
-  postfix: '',
-  thresholds: '10, 30',
-  // https://github.com/grafana/grafana/blob/v4.1.1/public/app/plugins/panel/singlestat/module.ts#L57
-  colors: ['rgba(245, 54, 54, 0.9)', 'rgba(237, 129, 40, 0.89)', 'rgba(50, 172, 45, 0.97)'],
-  colorsKeyMappingDefault: 'rgba(245, 54, 54, 0.9)',
-  colorKeyMappings: [],
-  nullMapping: undefined,
-  tooltipMode: TooltipMode.ALL_SERIES,
-  opacity: 0.5
-};
-
 class Ctrl extends MetricsPanelCtrl {
   static templateUrl = 'partials/template.html';
 
   public mapper: Mapper;
-  public items: ProgressItem[];
 
-  private _panelConfig: PanelConfig;
+  // TODO: rename progressBars
+  public items: ProgressBar[];
+
+  private _panelConfig: PanelConfig.PanelConfig;
   private _element: any;
 
   private _seriesList: any;
 
   private _tooltip: GraphTooltip;
 
-  private statNameOptions = _.values(StatType);
+  private statNameOptions = _.values(PanelConfig.StatType);
   private statProgressTypeOptions = [ 'max value', 'shared' ];
   private coloringTypeOptions = [ 'auto', 'thresholds', 'key mapping' ];
-  private titleViewTypeOptions = _.values(TitleViewOptions);
+  private titleViewTypeOptions = _.values(PanelConfig.TitleViewOptions);
   private sortingOrderOptions = [ 'none', 'increasing', 'decreasing' ];
   private valueLabelTypeOptions = [ 'absolute', 'percentage' ];
   // TODO: change option names or add a tip in editor
   private mappingTypeOptions = ['datapoint to datapoint', 'target to datapoint'];
-  private tooltipModeOptions = _.values(TooltipMode);
+  private tooltipModeOptions = _.values(PanelConfig.TooltipMode);
 
   // field for updating tooltip on rendering and storing previous state
   private _lastHoverEvent: HoverEvent;
@@ -88,9 +60,9 @@ class Ctrl extends MetricsPanelCtrl {
   constructor($scope: any, $injector: any, public templateSrv: any) {
     super($scope, $injector);
 
-    _.defaults(this.panel, DEFAULTS);
+    _.defaults(this.panel, PanelConfig.DEFAULTS);
 
-    this._panelConfig = new PanelConfig(this.panel);
+    this._panelConfig = new PanelConfig.PanelConfig(this.panel);
     this._initStyles();
 
     this.mapper = new Mapper(this._panelConfig, this.templateSrv);
@@ -161,7 +133,7 @@ class Ctrl extends MetricsPanelCtrl {
       item.title, // previously wwe showed serie.alias || serie.target
       [{
         value: item.formattedValue,
-        color: item.color
+        color: item.colors[0] // TODO: use other colors here
       }]
     ));
     this._tooltip.show(event.event, tooltipItems, this.panel.tooltipMode);

--- a/src/panel_config.ts
+++ b/src/panel_config.ts
@@ -27,7 +27,6 @@ export const DEFAULTS = {
   // TODO: skip multiple columns
   skipColumn: '',
   statNameOptionValue: StatType.CURRENT,
-  statProgressType: 'shared',
   statProgressMaxValue: null,
   coloringType: ColoringType.PALLETE,
   titleViewType: TitleViewOptions.SEPARATE_TITLE_LINE,

--- a/src/panel_config.ts
+++ b/src/panel_config.ts
@@ -10,6 +10,12 @@ export enum TitleViewOptions {
   INLINE = 'Inline'
 };
 
+export enum ColoringType {
+  PALLETE = 'pallete',
+  THRESHOLDS = 'thresholds',
+  KEY_MAPPING = 'key mapping'
+}
+
 export enum TooltipMode {
   NONE = 'none',
   SINGLE = 'single',
@@ -23,7 +29,7 @@ export const DEFAULTS = {
   statNameOptionValue: StatType.CURRENT,
   statProgressType: 'shared',
   statProgressMaxValue: null,
-  coloringType: 'auto',
+  coloringType: ColoringType.PALLETE,
   titleViewType: TitleViewOptions.SEPARATE_TITLE_LINE,
   sortingOrder: 'none',
   valueLabelType: 'percentage',
@@ -46,6 +52,11 @@ export class PanelConfig {
   private _panel: any;
   public constructor(panel: any) {
     this._panel = panel;
+
+    // migrations
+    if(this.getValue('coloringType') === 'auto') {
+      this.setValue('coloringType', ColoringType.PALLETE);
+    }
   }
 
   public getValue(key: string): any {

--- a/src/panel_config.ts
+++ b/src/panel_config.ts
@@ -1,3 +1,47 @@
+export enum StatType {
+  CURRENT = 'current',
+  MIN = 'min',
+  MAX = 'max',
+  TOTAL = 'total'
+};
+
+export enum TitleViewOptions {
+  SEPARATE_TITLE_LINE = 'Separate title line',
+  INLINE = 'Inline'
+};
+
+export enum TooltipMode {
+  NONE = 'none',
+  SINGLE = 'single',
+  ALL_SERIES = 'all series'
+};
+
+export const DEFAULTS = {
+  keyColumn: '',
+  // TODO: skip multiple columns
+  skipColumn: '',
+  statNameOptionValue: StatType.CURRENT,
+  statProgressType: 'shared',
+  statProgressMaxValue: null,
+  coloringType: 'auto',
+  titleViewType: TitleViewOptions.SEPARATE_TITLE_LINE,
+  sortingOrder: 'none',
+  valueLabelType: 'percentage',
+  mappingType: 'datapoint to datapoint',
+  alias: '',
+  prefix: '',
+  postfix: '',
+  thresholds: '10, 30',
+  // https://github.com/grafana/grafana/blob/v4.1.1/public/app/plugins/panel/singlestat/module.ts#L57
+  colors: ['rgba(245, 54, 54, 0.9)', 'rgba(237, 129, 40, 0.89)', 'rgba(50, 172, 45, 0.97)'],
+  colorsKeyMappingDefault: 'rgba(245, 54, 54, 0.9)',
+  colorKeyMappings: [],
+  nullMapping: undefined,
+  tooltipMode: TooltipMode.ALL_SERIES,
+  opacity: 0.5
+};
+
+
 export class PanelConfig {
   private _panel: any;
   public constructor(panel: any) {

--- a/src/partials/options.html
+++ b/src/partials/options.html
@@ -225,7 +225,7 @@
     </div>
   </div>
 
-  <div ng-if="ctrl.panel.coloringType == 'thresholds'">
+  <div ng-if="ctrl.panel.coloringType == 'thresholds' || ctrl.panel.coloringType == 'pallete'">
     <div class="gf-form">
       <label class="gf-form-label width-8">Thresholds
         <tip>

--- a/src/partials/options.html
+++ b/src/partials/options.html
@@ -37,18 +37,6 @@
     </div>
   </div>
 
-  <div class="gf-form">
-    <label class="gf-form-label width-8">Progress Type</label>
-    <div class="gf-form-select-wrapper width-12">
-      <select
-        class="gf-form-input"
-        ng-model="ctrl.panel.statProgressType"
-        ng-options="n for n in ctrl.statProgressTypeOptions"
-        ng-change="ctrl.render()"
-      ></select>
-    </div>
-  </div>
-
   <div class="gf-form" ng-if="ctrl.panel.statProgressType == 'max value'">
     <label class="gf-form-label width-8">
       Max Value

--- a/src/partials/options.html
+++ b/src/partials/options.html
@@ -30,26 +30,11 @@
     <div class="gf-form-select-wrapper width-12">
       <select
         class="gf-form-input"
-        ng-model="ctrl.panel.statNameOptionValue"
+        ng-model="ctrl.panel.statNameOptionValue" 
         ng-options="n for n in ctrl.statNameOptions"
         ng-change="ctrl.render()"
       ></select>
     </div>
-  </div>
-
-  <div class="gf-form" ng-if="ctrl.panel.statProgressType == 'max value'">
-    <label class="gf-form-label width-8">
-      Max Value
-      <tip>Max value will be equal to max progress in auto mode</tip>
-    </label>
-    <input
-      type="number"
-      class="gf-form-input width-12"
-      placeholder="auto" data-placement="right"
-      ng-model="ctrl.panel.statProgressMaxValue"
-      ng-change="ctrl.render()"
-      ng-model-onblur
-    />
   </div>
 
   <div class="gf-form">

--- a/src/partials/template.html
+++ b/src/partials/template.html
@@ -1,33 +1,33 @@
 <div class="progress-list-panel">
   <div ng-if="!ctrl.isPanelAlert">
     <div 
-      ng-repeat="item in items"
+      ng-repeat="progressBar in progressBars"
       class="list-item"
       ng-mousemove="ctrl.onHover({ index: $index, event: $event })"
       ng-mouseleave="ctrl.onMouseLeave()"
     >
-      <div class="list-item-title" ng-bind-html="item.title"></div>
+      <div class="list-item-title" ng-bind-html="progressBar.title"></div>
       <div
         class="list-item-content"
-        style="width: {{ item.aggregatedProgress }}%;"
+        style="width: {{ progressBar.aggregatedProgress }}%;"
       >
         <div
-          ng-repeat="percentValue in item.percentValues track by $index"
+          ng-repeat="percentValue in progressBar.percentValues track by $index"
           style="
             width: {{ percentValue }}%;
             display: inline-block;
-            background-color: {{ item.colors[$index] }};
-            opacity: {{ item.opacity }};
-            height: {{ item.titleParams.barHeight }}px;
-            margin-top: {{ item.titleParams.titleTopMargin }}px;
+            background-color: {{ progressBar.colors[$index] }};
+            opacity: {{ progressBar.opacity }};
+            height: {{ progressBar.titleParams.barHeight }}px;
+            margin-top: {{ progressBar.titleParams.titleTopMargin }}px;
           "
           class="progress-bar-line"
         >
         <span
-          style="margin-top: {{ item.titleParams.valueTopMargin }}px;"
+          style="margin-top: {{ progressBar.titleParams.valueTopMargin }}px;"
           class="list-item-value progress-bar-value"
         >
-          {{ item.formattedValue }}
+          {{ progressBar.formattedValue }}
         </span>
         </div>
       </div>

--- a/src/partials/template.html
+++ b/src/partials/template.html
@@ -23,14 +23,13 @@
             margin-top: {{ progressBar.titleParams.titleTopMargin }}px;
           "
           class="progress-bar-line"
-        >
+        ></div>
         <span
           style="margin-top: {{ progressBar.titleParams.valueTopMargin }}px;"
           class="list-item-value progress-bar-value"
         >
           {{ progressBar.formattedValue }}
         </span>
-        </div>
       </div>
     </div>
   </div>

--- a/src/partials/template.html
+++ b/src/partials/template.html
@@ -32,8 +32,8 @@
         </div>
       </div>
     </div>
-    <div ng-if="ctrl.isPanelAlert" class="datapoints-warning flot-temp-elem">
-      <div ng-bind-html="ctrl.panelAlertMessage"></div>
-    </div>
+  </div>
+  <div ng-if="ctrl.isPanelAlert" class="datapoints-warning flot-temp-elem">
+    <div ng-bind-html="ctrl.panelAlertMessage"></div>
   </div>
 </div>

--- a/src/partials/template.html
+++ b/src/partials/template.html
@@ -7,7 +7,7 @@
       ng-mouseleave="ctrl.onMouseLeave()"
       ng-class="{ 'progress-bar-active': progressBar.active }"
     >
-      <div class="list-item-title" ng-bind-html="progressBar.title"></div>
+      <div class="progress-bar-title" ng-bind-html="progressBar.title"></div>
       <div
         class="list-item-content"
         style="width: {{ progressBar.aggregatedProgress }}%;"

--- a/src/partials/template.html
+++ b/src/partials/template.html
@@ -1,10 +1,11 @@
 <div class="progress-list-panel">
   <div ng-if="!ctrl.isPanelAlert">
     <div 
-      ng-repeat="progressBar in progressBars"
-      class="list-item"
+      ng-repeat="progressBar in ctrl.progressBars"
+      class="progress-bar"
       ng-mousemove="ctrl.onHover({ index: $index, event: $event })"
       ng-mouseleave="ctrl.onMouseLeave()"
+      ng-class="{ 'progress-bar-active': progressBar.active }"
     >
       <div class="list-item-title" ng-bind-html="progressBar.title"></div>
       <div

--- a/src/progress_bar.ts
+++ b/src/progress_bar.ts
@@ -1,4 +1,4 @@
-import { PanelConfig, TitleViewOptions } from './panel_config';
+import { ColoringType, PanelConfig, TitleViewOptions } from './panel_config';
 import { getFormattedValue } from './value_formatter';
 
 import * as _ from 'lodash';
@@ -43,7 +43,7 @@ export class ProgressBar {
       this._bars.push({
         name: this._keys[i],
         value: this._values[i],
-        color: mapValue2Color(this._values[i], this._panelConfig)
+        color: mapValue2Color(this._values[i], i, this._panelConfig)
       });
     }
   }
@@ -126,15 +126,17 @@ export class ProgressBar {
 
 /** VIEW **/
 
-function mapValue2Color(value: number, _panelConfig: any) {
-  var colorType = _panelConfig.getValue('coloringType');
-  if(colorType === 'auto') {
-    return 'auto'
+function mapValue2Color(value: number, index: number, _panelConfig: any) {
+  var colorType: ColoringType = _panelConfig.getValue('coloringType');
+  var colors: string[] = _panelConfig.getValue('colors');
+
+  if(colorType === ColoringType.PALLETE) {
+    // TODO: pallete resolving
+    return colors[index % colors.length];
   }
-  if(colorType === 'thresholds') {
+  if(colorType === ColoringType.THRESHOLDS) {
     // TODO: parse only once
     var thresholds = _panelConfig.getValue('thresholds').split(',').map(parseFloat);
-    var colors = _panelConfig.getValue('colors');
     if(colors.length <= thresholds.length) {
       // we add one because a threshold is a cut of the range of values
       throw new Error('Number of colors must be at least as number as threasholds + 1');
@@ -146,7 +148,7 @@ function mapValue2Color(value: number, _panelConfig: any) {
     }
     return colors[0];
   }
-  if(colorType === 'key mapping') {
+  if(colorType === ColoringType.KEY_MAPPING) {
     var colorKeyMappings = _panelConfig.getValue('colorKeyMappings') as any[];
     var keyColorMapping = _.find(colorKeyMappings, k => k.key === this._key);
     if(keyColorMapping === undefined) {

--- a/src/progress_bar.ts
+++ b/src/progress_bar.ts
@@ -1,0 +1,92 @@
+import { PanelConfig, TitleViewOptions } from './panel_config';
+import { getFormattedValue } from './value_formatter';
+
+import * as _ from 'lodash';
+
+
+type ProgressBarTitle = {
+  barHeight: number,
+  titleTopMargin: number,
+  valueTopMargin: number
+};
+
+export class ProgressBar {
+  constructor(
+    private _panelConfig: PanelConfig,
+    private _title: string,
+    private _keys: string[],
+    private _values: number[],
+    private _maxValue: number
+  ) {
+    if(this._keys.length !== this._values.length) {
+      throw new Error('keys amount should be equal to values amount');
+    }
+  }
+
+  get title(): string {
+    return this._title;
+  }
+
+  get keys(): string[] {
+    return this._keys;
+  }
+
+  get values(): number[] {
+    return this._values;
+  }
+
+  get sumOfValues(): number {
+    return _.sum(this.values);
+  }
+
+  get percentValues(): number[] {
+    // TODO: this.sumOfValues * 1.1 is a hack to make sure bars don't wrap
+    // (they are wrapped when total width > 98%)
+    return this.values.map(
+      value => Math.floor(value / (this.sumOfValues * 1.1) * 100)
+    );
+  }
+
+  get colors(): string[] {
+    // TODO: customize colors
+    return ['green', 'yellow', 'red'];
+  }
+
+  get aggregatedProgress(): number {
+    return (_.sum(this.values) / this._maxValue) * 100;
+  }
+
+  get formattedValue(): string {
+    return getFormattedValue(
+      this.sumOfValues,
+      this._panelConfig.getValue('prefix'),
+      this._panelConfig.getValue('postfix'),
+      this._panelConfig.getValue('decimals')
+    );
+  }
+
+  get titleParams(): ProgressBarTitle {
+    const titleType = this._panelConfig.getValue('titleViewType');
+
+    switch(titleType) {
+      case TitleViewOptions.SEPARATE_TITLE_LINE:
+        return {
+          barHeight: 8,
+          titleTopMargin: 0,
+          valueTopMargin: -12
+        };
+      case TitleViewOptions.INLINE:
+        return {
+          barHeight: 20,
+          titleTopMargin: -20,
+          valueTopMargin: -18
+        };
+      default:
+        throw new Error(`Wrong titleType: ${titleType}`);
+    }
+  }
+
+  get opacity(): string {
+    return this._panelConfig.getValue('opacity');
+  }
+}

--- a/src/progress_bar.ts
+++ b/src/progress_bar.ts
@@ -4,11 +4,20 @@ import { getFormattedValue } from './value_formatter';
 import * as _ from 'lodash';
 
 
-type ProgressBarTitle = {
+type ProgressTitle = {
   barHeight: number,
   titleTopMargin: number,
   valueTopMargin: number
 };
+
+/**
+ * It's model for rendering bars in view (partial) and tooltip
+ */
+export type Bar = {
+  name: string,
+  value: number,
+  color: string
+}
 
 export class ProgressBar {
   constructor(
@@ -65,7 +74,7 @@ export class ProgressBar {
     );
   }
 
-  get titleParams(): ProgressBarTitle {
+  get titleParams(): ProgressTitle {
     const titleType = this._panelConfig.getValue('titleViewType');
 
     switch(titleType) {

--- a/src/progress_bar.ts
+++ b/src/progress_bar.ts
@@ -127,15 +127,17 @@ export class ProgressBar {
 /** VIEW **/
 
 function mapValue2Color(value: number, _panelConfig: any) {
-  var colorType = this._panelConfig.getValue('coloringType');
+  var colorType = _panelConfig.getValue('coloringType');
   if(colorType === 'auto') {
     return 'auto'
   }
   if(colorType === 'thresholds') {
-    var thresholds = this._panelConfig.getValue('thresholds').split(',').map(parseFloat);
-    var colors = this._panelConfig.getValue('colors');
-    if(colors.length != thresholds.length) {
-      throw new Error('Bad colors/thresholds config: length mismatch');
+    // TODO: parse only once
+    var thresholds = _panelConfig.getValue('thresholds').split(',').map(parseFloat);
+    var colors = _panelConfig.getValue('colors');
+    if(colors.length <= thresholds.length) {
+      // we add one because a threshold is a cut of the range of values
+      throw new Error('Number of colors must be at least as number as threasholds + 1');
     }
     for(var i = thresholds.length; i > 0; i--) {
       if(value >= thresholds[i - 1]) {
@@ -145,10 +147,10 @@ function mapValue2Color(value: number, _panelConfig: any) {
     return colors[0];
   }
   if(colorType === 'key mapping') {
-    var colorKeyMappings = this._panelConfig.getValue('colorKeyMappings') as any[];
+    var colorKeyMappings = _panelConfig.getValue('colorKeyMappings') as any[];
     var keyColorMapping = _.find(colorKeyMappings, k => k.key === this._key);
     if(keyColorMapping === undefined) {
-      return this._panelConfig.getValue('colorsKeyMappingDefault');
+      return _panelConfig.getValue('colorsKeyMappingDefault');
     }
     return keyColorMapping.color;
   }

--- a/src/progress_bar.ts
+++ b/src/progress_bar.ts
@@ -46,35 +46,23 @@ export class ProgressBar {
         color: mapValue2Color(this._values[i], i, this._panelConfig)
       });
     }
+
+    // bad code starts:
+
   }
 
-  get active(): boolean {
-    return this._active;
-  }
+  get active(): boolean { return this._active; }
+  set active(value: boolean) { this._active = value;}
 
-  set active(value: boolean) {
-    this._active = value;
-  }
+  get title(): string { return this._title; }
 
-  get title(): string {
-    return this._title;
-  }
+  get keys(): string[] { return this._keys; }
 
-  get keys(): string[] {
-    return this._keys;
-  }
+  get values(): number[] { return this._values; }
 
-  get values(): number[] {
-    return this._values;
-  }
+  get bars(): Bar[] { return this._bars; }
 
-  get bars(): Bar[] {
-    return this._bars;
-  }
-
-  get sumOfValues(): number {
-    return _.sum(this.values);
-  }
+  get sumOfValues(): number { return _.sum(this.values); }
 
   get percentValues(): number[] {
     // TODO: this.sumOfValues * 1.1 is a hack to make sure bars don't wrap
@@ -131,7 +119,6 @@ function mapValue2Color(value: number, index: number, _panelConfig: any) {
   var colors: string[] = _panelConfig.getValue('colors');
 
   if(colorType === ColoringType.PALLETE) {
-    // TODO: pallete resolving
     return colors[index % colors.length];
   }
   if(colorType === ColoringType.THRESHOLDS) {


### PR DESCRIPTION
## Problem
Colors functionality [doesn't work as it should](https://github.com/CorpGlory/grafana-progress-list/issues/66) this PR makes coloring for mulibars.

**statProgressType feature doens't work (it didn't work before)** 

The fun is that the actual coloring of muliamp is not implemented, because someone produced such garbage (took from `template.html`): 

```
<div
        class="list-item-content"
        style="width: {{ progressBar.aggregatedProgress }}%;"
      >
        <div
          ng-repeat="percentValue in progressBar.percentValues track by $index"
          style="
            width: {{ percentValue }}%;
            display: inline-block;
            background-color: {{ progressBar.colors[$index] }};
            opacity: {{ progressBar.opacity }};
            height: {{ progressBar.titleParams.barHeight }}px;
            margin-top: {{ progressBar.titleParams.titleTopMargin }}px;
          "
          class="progress-bar-line"
        ></div>
        <span
          style="margin-top: {{ progressBar.titleParams.valueTopMargin }}px;"
          class="list-item-value progress-bar-value"
        >
          {{ progressBar.formattedValue }}
        </span>
      </div>
```

## Changes
### ProgressBar
`MultiProgressItem` and `ProgressItem` merged into new class `ProgressBar` in `progress_bar.ts`.
Now it's "bar", not "item". It's comes naturally from the fact that we have single template
for rendering bars. 
* `TitleViewOptions` moved to `progress_bar.ts` and renamed to `ProgressBarTitle`

### New Coloring logic
We have coloring type called "auto". I think it's not the best name because it's unclear how exactly the coloring happens.
In this PR I propose "palette" coloring (migration added). Now `panel._panelConfig.color` used both for `threshold` and `pallete` coloring types.

Now there is a new class `ColoringType` in `panel_config.ts`

#### Progress bar border
![image](https://user-images.githubusercontent.com/1022757/99918373-ad99cb80-2d16-11eb-86ff-f8486f3b92f4.png)

### ProgressBarElement (or just Bar)
Class `Bar` (I named it `ProgressBarElement` in the beginning) in `progress_bar.ts` is the model (in terms of MVC pattern) for rendering in the template and tooltip. So we don't need class `TooltipValue` in `graph_tooltip.ts`.
The name `Bar` is better than `ProgressBarElement` because it better represents the idea: `ProgressBar` is "complex" structure which contains all info about the progress bar, when `bar` is just a small piece, it's the model for rectangle we render, which has different representation in tooltip. OMG, it's MVC ideas again here!

###  Progress bar activation
There is a problem in the rendering of tooltip: on each selection we need to select activated progress bar by traversing all list of values, which is linear from number of elements. We can do it faster and better: let's keep the flag of activation in `ProgressBar`. So there is a new logic of setting `active` flag in `ProgressBar`. It really improved performance of the app btw

#### Progress bar activation style
Title and value become bold on selection:
![image](https://user-images.githubusercontent.com/1022757/99916426-76252200-2d0a-11eb-87ce-c8b3a0ab5e7f.png)


### Config types
`TitleViewOptions` and `DEFAULTS`  moved from `module.ts` to `config.ts`, `TooltipMode` moved from `graph_tooltip.ts` to `config.ts` also.
I think it's a better place to keep types of our panel options.

### Multi values in tooltip
Just because we make soft right, the tooltip looks like this now:
![image](https://user-images.githubusercontent.com/1022757/99915691-7cfd6600-2d05-11eb-8913-d038aaaed876.png)
And it fixes https://github.com/CorpGlory/grafana-progress-list/issues/60


### Other
* Rename of "Coloring" to "Bars Coloring" in the editor tab
* Make alert messages (like loading) work again:  element `<div ng-if="ctrl.isPanelAlert" >`  somehow was inside `<div ng-if="!ctrl.isPanelAlert">` so it was always hidden
* Remove `this.$scope.items` from `module.ts`,  `template.html` accesses the items via `ctrl.item`, which called now `ctrl.progressBars`
* Value of progress bar was rendered as many inner bars in `progressBar` in `template.ts` -- we need to render the value only once
* In `panel.base.css` all inner elements of `.progress-bar`  got prefix `.progress-bar` to render faster and avoid name collisions
* remove of `link` method from `module.ts` -- we don't need `this._element` variable 

## Misc
* [ProgressItem how it was on master branch](https://github.com/CorpGlory/grafana-progress-list/blob/a88abe3ba4abe005c8e6efcc6ec4c41f3fb7b11e/src/mapper.ts#L105)