### PR TITLE
Bar coloring

### DIFF
--- a/src/partials/options.html
+++ b/src/partials/options.html
@@ -163,7 +163,7 @@
       </label>
       <!-- TODO: better style -->
       <textarea
-        class="gf-form-input"
+        class="gf-form-input width-12"
         ng-model="ctrl.panel.alias"
         ng-change="ctrl.render()"
         ng-model-onblur
@@ -180,7 +180,7 @@
       min="0"
       max="1"
       step="0.1"
-      class="gf-form-input width-11"
+      class="gf-form-input width-12"
       ng-model="ctrl.panel.opacity"
       ng-blur="ctrl.render()"
     />
@@ -188,7 +188,7 @@
 
   <div class="gf-form">
     <label class="gf-form-label width-8">Type</label>
-    <div class="gf-form-select-wrapper width-11">
+    <div class="gf-form-select-wrapper width-12">
       <select
         class="gf-form-input"
         ng-model="ctrl.panel.coloringType"
@@ -207,7 +207,7 @@
       </label>
       <input
         type="text"
-        class="gf-form-input width-11"
+        class="gf-form-input width-12"
         ng-model="ctrl.panel.thresholds"
         ng-blur="ctrl.render()"
         placeholder="50,80"

--- a/src/progress_bar.ts
+++ b/src/progress_bar.ts
@@ -85,6 +85,10 @@ export class ProgressBar {
     );
   }
 
+  get colors(): string[] {
+    return _.map(this._bars, bar => bar.color);
+  }
+
   // it should go somewhere to view
   get titleParams(): ProgressTitle {
     const titleType = this._panelConfig.getValue('titleViewType');


### PR DESCRIPTION
This PR fixes the problem of broken bar colors.

## Changes:
   - add `colors` getter in the `ProgressBar` class,  which is used in `template.html`

## Other:
  - keep options tab in one style: make inputs the same width

### BEFORE:
![image](https://user-images.githubusercontent.com/39257464/100720542-11c32c00-33b6-11eb-8439-0e33cd7a4728.png)

![image](https://user-images.githubusercontent.com/39257464/100720635-34554500-33b6-11eb-807a-feac3d15bb8f.png)



### AFTER:
![image](https://user-images.githubusercontent.com/39257464/100720330-babd5700-33b5-11eb-8fd2-32baaba35768.png)

![image](https://user-images.githubusercontent.com/39257464/100720441-e80a0500-33b5-11eb-9b9f-20331066db96.png)

