### PR TITLE
Key mapping colors

### DIFF
--- a/src/partials/options.html
+++ b/src/partials/options.html
@@ -253,7 +253,8 @@
     </div>
 
     <div class="gf-form">
-      <label class="gf-form-label width-8">Default
+      <label class="gf-form-label width-11">
+        Default
         <tip>Color for all other keys</tip>
       </label>
       <span class="gf-form-label">

--- a/src/partials/options.html
+++ b/src/partials/options.html
@@ -198,7 +198,7 @@
     </div>
   </div>
 
-  <div ng-if="ctrl.panel.coloringType == 'thresholds' || ctrl.panel.coloringType == 'pallete'">
+  <div ng-if="ctrl.panel.coloringType == 'thresholds'">
     <div class="gf-form">
       <label class="gf-form-label width-8">Thresholds
         <tip>
@@ -213,6 +213,9 @@
         placeholder="50,80"
       />
     </div>
+  </div>
+
+  <div ng-if="ctrl.panel.coloringType == 'thresholds' || ctrl.panel.coloringType == 'pallete'">
     <div class="gf-form">
       <label class="gf-form-label width-8">Colors</label>
       <span class="gf-form-label">

--- a/src/partials/options.html
+++ b/src/partials/options.html
@@ -271,7 +271,7 @@
       <div class="gf-form-button-row">
         <button class="btn btn-inverse" ng-click="ctrl.addColorKeyMapping()">
           <i class="fa fa-plus"></i>
-          Add a key color mapping
+          &nbsp;Add a key color mapping
         </button>
       </div>
     </div>

--- a/src/progress_bar.ts
+++ b/src/progress_bar.ts
@@ -43,7 +43,7 @@ export class ProgressBar {
       this._bars.push({
         name: this._keys[i],
         value: this._values[i],
-        color: mapValue2Color(this._values[i], this._title, i, this._panelConfig)
+        color: mapValue2Color(this._values[i], this._keys[i], i, this._panelConfig)
       });
     }
 
@@ -118,7 +118,7 @@ export class ProgressBar {
 
 /** VIEW **/
 
-function mapValue2Color(value: number, title: string, index: number, _panelConfig: any): string {
+function mapValue2Color(value: number, key: string, index: number, _panelConfig: any): string {
   const colorType: ColoringType = _panelConfig.getValue('coloringType');
   const colors: string[] = _panelConfig.getValue('colors');
 
@@ -140,12 +140,12 @@ function mapValue2Color(value: number, title: string, index: number, _panelConfi
       return colors[0];
     case ColoringType.KEY_MAPPING:
       const colorKeyMappings = _panelConfig.getValue('colorKeyMappings') as any[];
-      const keyColorMapping = _.find(colorKeyMappings, k => k.key === title);
+      const keyColorMapping = _.find(colorKeyMappings, k => k.key === key);
       if(keyColorMapping === undefined) {
         return _panelConfig.getValue('colorsKeyMappingDefault');
       }
       return keyColorMapping.color;
     default:
       throw new Error('Unknown color type ' + colorType);
-  }  
+  }
 }

--- a/src/progress_bar.ts
+++ b/src/progress_bar.ts
@@ -43,7 +43,7 @@ export class ProgressBar {
       this._bars.push({
         name: this._keys[i],
         value: this._values[i],
-        color: mapValue2Color(this._values[i], i, this._panelConfig)
+        color: mapValue2Color(this._values[i], this._title, i, this._panelConfig)
       });
     }
 
@@ -118,7 +118,7 @@ export class ProgressBar {
 
 /** VIEW **/
 
-function mapValue2Color(value: number, index: number, _panelConfig: any): string {
+function mapValue2Color(value: number, title: string, index: number, _panelConfig: any): string {
   var colorType: ColoringType = _panelConfig.getValue('coloringType');
   var colors: string[] = _panelConfig.getValue('colors');
 
@@ -140,8 +140,8 @@ function mapValue2Color(value: number, index: number, _panelConfig: any): string
     return colors[0];
   }
   if(colorType === ColoringType.KEY_MAPPING) {
-    var colorKeyMappings = _panelConfig.getValue('colorKeyMappings') as any[];
-    var keyColorMapping = _.find(colorKeyMappings, k => k.key === this._key);
+    const colorKeyMappings = _panelConfig.getValue('colorKeyMappings') as any[];
+    const keyColorMapping = _.find(colorKeyMappings, k => k.key === title);
     if(keyColorMapping === undefined) {
       return _panelConfig.getValue('colorsKeyMappingDefault');
     }

--- a/src/progress_bar.ts
+++ b/src/progress_bar.ts
@@ -119,33 +119,33 @@ export class ProgressBar {
 /** VIEW **/
 
 function mapValue2Color(value: number, title: string, index: number, _panelConfig: any): string {
-  var colorType: ColoringType = _panelConfig.getValue('coloringType');
-  var colors: string[] = _panelConfig.getValue('colors');
+  const colorType: ColoringType = _panelConfig.getValue('coloringType');
+  const colors: string[] = _panelConfig.getValue('colors');
 
-  if(colorType === ColoringType.PALLETE) {
-    return colors[index % colors.length];
-  }
-  if(colorType === ColoringType.THRESHOLDS) {
-    // TODO: parse only once
-    var thresholds = _panelConfig.getValue('thresholds').split(',').map(parseFloat);
-    if(colors.length <= thresholds.length) {
-      // we add one because a threshold is a cut of the range of values
-      throw new Error('Number of colors must be at least as number as threasholds + 1');
-    }
-    for(var i = thresholds.length; i > 0; i--) {
-      if(value >= thresholds[i - 1]) {
-        return colors[i];
+  switch(colorType) {
+    case ColoringType.PALLETE:
+      return colors[index % colors.length];
+    case ColoringType.THRESHOLDS:
+      // TODO: parse only once
+      const thresholds = _panelConfig.getValue('thresholds').split(',').map(parseFloat);
+      if(colors.length <= thresholds.length) {
+        // we add one because a threshold is a cut of the range of values
+        throw new Error('Number of colors must be at least as number as threasholds + 1');
       }
-    }
-    return colors[0];
-  }
-  if(colorType === ColoringType.KEY_MAPPING) {
-    const colorKeyMappings = _panelConfig.getValue('colorKeyMappings') as any[];
-    const keyColorMapping = _.find(colorKeyMappings, k => k.key === title);
-    if(keyColorMapping === undefined) {
-      return _panelConfig.getValue('colorsKeyMappingDefault');
-    }
-    return keyColorMapping.color;
-  }
-  throw new Error('Unknown color type ' + colorType);
+      for(let i = thresholds.length; i > 0; i--) {
+        if(value >= thresholds[i - 1]) {
+          return colors[i];
+        }
+      }
+      return colors[0];
+    case ColoringType.KEY_MAPPING:
+      const colorKeyMappings = _panelConfig.getValue('colorKeyMappings') as any[];
+      const keyColorMapping = _.find(colorKeyMappings, k => k.key === title);
+      if(keyColorMapping === undefined) {
+        return _panelConfig.getValue('colorsKeyMappingDefault');
+      }
+      return keyColorMapping.color;
+    default:
+      throw new Error('Unknown color type ' + colorType);
+  }  
 }


### PR DESCRIPTION
This PR fixes broken key mapping.

#### Problem:
   - After selecting `key mapping`  coloring type, you will get "Can't map the received metrics"

### Changes:
   - `mapValue2Color` function:
        - use a new `key` arg instead of non-existent `this._key` field
        - refactor: use switch construction
 
### Other UI updates:
   - hide `thresholds` option when `pallete` type is active 