### PR TITLE
Percentage value type

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -42,7 +42,7 @@ class Ctrl extends MetricsPanelCtrl {
 
   private titleViewTypeOptions = _.values(PanelConfig.TitleViewOptions);
   private sortingOrderOptions = [ 'none', 'increasing', 'decreasing' ];
-  private valueLabelTypeOptions = [ 'absolute', 'percentage' ];
+  private valueLabelTypeOptions = _.values(PanelConfig.ValueLabelType);
   // TODO: change option names or add a tip in editor
   private mappingTypeOptions = ['datapoint to datapoint', 'target to datapoint'];
   private tooltipModeOptions = _.values(PanelConfig.TooltipMode);
@@ -123,6 +123,30 @@ class Ctrl extends MetricsPanelCtrl {
       this.onHover(this._lastHoverEvent);
     }
     this._panelAlert.active = false;
+  }
+
+  onValueLabelTypeChange(): void {
+    this.updatePostfix();
+    this._onRender();
+  }
+
+  updatePostfix(): void {
+    const valueLabelType = this._panelConfig.getValue('valueLabelType');
+    const postfixValue = this.panel.postfix;
+    switch(valueLabelType) {
+      case PanelConfig.ValueLabelType.ABSOLUTE:
+        if(postfixValue === '%') {
+          this.panel.postfix = '';
+        }
+        break;
+      case PanelConfig.ValueLabelType.PERCENTAGE:
+        if(postfixValue === '') {
+          this.panel.postfix = '%';
+        }
+        break;
+      default:
+        throw new Error(`Unknown value label type: ${valueLabelType}`);
+    }
   }
 
   onHover(event: HoverEvent) {

--- a/src/panel_config.ts
+++ b/src/panel_config.ts
@@ -16,6 +16,11 @@ export enum ColoringType {
   KEY_MAPPING = 'key mapping'
 }
 
+export enum ValueLabelType {
+  PERCENTAGE = 'percentage',
+  ABSOLUTE = 'absolute'
+}
+
 export enum TooltipMode {
   NONE = 'none',
   SINGLE = 'single',
@@ -31,7 +36,7 @@ export const DEFAULTS = {
   coloringType: ColoringType.PALLETE,
   titleViewType: TitleViewOptions.SEPARATE_TITLE_LINE,
   sortingOrder: 'none',
-  valueLabelType: 'percentage',
+  valueLabelType: ValueLabelType.ABSOLUTE,
   mappingType: 'datapoint to datapoint',
   alias: '',
   prefix: '',

--- a/src/partials/options.html
+++ b/src/partials/options.html
@@ -99,7 +99,7 @@
         class="gf-form-input"
         ng-model="ctrl.panel.valueLabelType"
         ng-options="n for n in ctrl.valueLabelTypeOptions"
-        ng-change="ctrl.render()"
+        ng-change="ctrl.onValueLabelTypeChange()"
       ></select>
     </div>
   </div>

--- a/src/partials/template.html
+++ b/src/partials/template.html
@@ -15,7 +15,7 @@
         "
       >
         <p class="progress-bar-title">{{ progressBar.title }}</p>
-        <p class="progress-bar-value">{{ progressBar.formattedValue }}</p>
+        <p class="progress-bar-value">{{ progressBar.formattedTotalValue }}</p>
       </div>
       <div class="progress-bar-line-row">
         <div

--- a/src/progress_bar.ts
+++ b/src/progress_bar.ts
@@ -76,7 +76,7 @@ export class ProgressBar {
   }
 
   get aggregatedProgress(): number {
-    return (_.sum(this.values) / this._maxTotalValue) * 100;
+    return (this.sumOfValues / this._maxTotalValue) * 100;
   }
 
   get totalValue(): number {
@@ -85,7 +85,7 @@ export class ProgressBar {
       case ValueLabelType.ABSOLUTE:
         return this.sumOfValues;
       case ValueLabelType.PERCENTAGE:
-        return (this.sumOfValues / this._maxTotalValue) * 100;
+        return this.aggregatedProgress;
       default:
         throw new Error(`Unknown value label type: ${valueLabelType}`);
     }

--- a/src/progress_bar.ts
+++ b/src/progress_bar.ts
@@ -1,4 +1,4 @@
-import { ColoringType, PanelConfig, TitleViewOptions } from './panel_config';
+import { ColoringType, PanelConfig, TitleViewOptions, ValueLabelType } from './panel_config';
 import { getFormattedValue } from './value_formatter';
 
 import * as _ from 'lodash';
@@ -38,7 +38,7 @@ export class ProgressBar {
     private _title: string,
     private _keys: string[], // maybe "_names" is better than "_keys"
     private _values: number[],
-    private _maxValue: number
+    private _maxTotalValue: number
   ) {
     if(this._keys.length !== this._values.length) {
       throw new Error('keys amount should be equal to values amount');
@@ -71,17 +71,29 @@ export class ProgressBar {
 
   get percentValues(): number[] {
     return this.values.map(
-      value => Math.floor(value / this.sumOfValues * 100)
+      value => value / this.sumOfValues * 100
     );
   }
 
   get aggregatedProgress(): number {
-    return (_.sum(this.values) / this._maxValue) * 100;
+    return (_.sum(this.values) / this._maxTotalValue) * 100;
   }
 
-  get formattedValue(): string {
+  get totalValue(): number {
+    const valueLabelType = this._panelConfig.getValue('valueLabelType');
+    switch(valueLabelType) {
+      case ValueLabelType.ABSOLUTE:
+        return this.sumOfValues;
+      case ValueLabelType.PERCENTAGE:
+        return (this.sumOfValues / this._maxTotalValue) * 100;
+      default:
+        throw new Error(`Unknown value label type: ${valueLabelType}`);
+    }
+  }
+
+  get formattedTotalValue(): string {
     return getFormattedValue(
-      this.sumOfValues,
+      this.totalValue,
       this._panelConfig.getValue('prefix'),
       this._panelConfig.getValue('postfix'),
       this._panelConfig.getValue('decimals')


### PR DESCRIPTION
This PR fixes broken percentage value type

### Changes:
   - fixes Percentage value type
   - add "%" sign in postfix on percentage value type selecting
   - `percentValues` getter: remove `Math.floor` from value calculation. Values are lost due to rounding.
   - add `ValueLabelType` enum
   - change default value type from `percentage` to `absolute`
   - add a new getter `totalValue`:  the value that is displayed for each bar
   
 ### Before:
 
![image](https://user-images.githubusercontent.com/39257464/102995323-dab5e580-4531-11eb-8753-1866c6ff740d.png)

 
 ### After:
 
 
![image](https://user-images.githubusercontent.com/39257464/102995227-a5a99300-4531-11eb-92e2-867b6c81e1ab.png)
